### PR TITLE
Исправить ошибку поиска для гостей в PHP 8

### DIFF
--- a/upload/include/dblayer/mysqli.php
+++ b/upload/include/dblayer/mysqli.php
@@ -158,7 +158,17 @@ class DBLayer
 
 	function free_result($query_id = false)
 	{
-		return $query_id ? @mysqli_free_result($query_id) : false;
+		if ($query_id)
+		{
+			$result = @mysqli_free_result($query_id);
+
+			if ($query_id === $this->query_result)
+				$this->query_result = false;
+
+			return $result;
+		}
+		else
+			return false;
 	}
 
 
@@ -182,7 +192,7 @@ class DBLayer
 	{
 		if ($this->link_id)
 		{
-			if (!is_bool($this->query_result))
+			if ($this->query_result instanceof mysqli_result)
 				@mysqli_free_result($this->query_result);
 
 			return @mysqli_close($this->link_id);


### PR DESCRIPTION
В поиске после каждого запроса (почти) происходит вызов метода free_result(), затем в подвале вызывается метод close(). В результате на результате последнего запроса для гостя вызывается два раза mysqli_free_result(). В PHP 8 это вызывает ошибку. Здесь костыль, который устанавливает $this->query_result = false, если метод  free_result() вызван на результате последнего запроса. P.S. В свое сборке давным давно просто удалил все вызовы free_result() в коде движка.